### PR TITLE
Updates to support rename of btrdb4-python repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Aside from basic unit tests, the test suite is configured to use [pyflakes](http
 
 When working on this codebase, keep in mind that the project is set up in a typical production/release/development cycle as described in _[A Successful Git Branching Model](http://nvie.com/posts/a-successful-git-branching-model/)_. A typical workflow is as follows:
 
-1. Select an issue from the [issues page](https://github.com/BTrDB/btrdb4-python/issues) - preferably one that is "ready" then move it to "in-progress" using labels or just comment that you are working on it.
+1. Select an issue from the [issues page](https://github.com/BTrDB/btrdb-python/issues) - preferably one that is "ready" then move it to "in-progress" using labels or just comment that you are working on it.
 
 2. Create a branch off of develop called "feature-[feature name]", work and commit into that branch.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,16 +21,18 @@ import sys
 sys.path.insert(0, os.path.abspath('_themes'))
 sys.path.insert(0, os.path.abspath('../..'))
 
+from btrdb.version import get_version
+
 # -- Project information -----------------------------------------------------
 
 project = 'btrdb'
-copyright = '2018, Michael P. Andersen'
+copyright = '2019, Michael P. Andersen'
 author = 'Michael P. Andersen'
 
 # The short X.Y version
-version = '5.0'
+version = get_version()
 # The full version, including alpha/beta/rc tags
-release = 'v5.0'
+release = 'v' + get_version()
 
 
 # -- General configuration ---------------------------------------------------
@@ -91,7 +93,7 @@ html_theme = 'alabaster'
 html_theme_options = {
     'show_powered_by': False,
     'github_user': 'BTrDB',
-    'github_repo': 'btrdb4-python',
+    'github_repo': 'btrdb-python',
     'travis_button': False,
     'github_banner': False,
     'show_related': False,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,8 @@
 Welcome to btrdb docs!
 ========================================
 
-.. image:: https://img.shields.io/travis/BTrDB/btrdb4-python/master.svg
-    :target: https://travis-ci.org/BTrDB/btrdb4-python
+.. image:: https://img.shields.io/travis/BTrDB/btrdb-python/master.svg
+    :target: https://travis-ci.org/BTrDB/btrdb-python
 
 .. image:: https://readthedocs.org/projects/btrdb/badge/?version=latest
     :target: https://btrdb.readthedocs.io/en/latest/

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -19,7 +19,7 @@ in the 4.x bindings are best used to speak to a 4.x BTrDB database.
 
 .. code-block:: bash
 
-    $ pip install btrdb==4.0.0
+    $ pip install btrdb==4.11.2
 
 
 To upgrade using pip:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ AUTHOR       = "Michael Andersen, Allen Leis"
 EMAIL        = "michael@steelcode.com"
 MAINTAINER   = "Michael Andersen"
 LICENSE      = "BSD-3-Clause"
-REPOSITORY   = "https://github.com/BTrDB/btrdb4-python"
+REPOSITORY   = "https://github.com/BTrDB/btrdb-python"
 PACKAGE      = "btrdb"
 URL          = "http://btrdb.io/"
 


### PR DESCRIPTION
This PR includes updates to support changing the repo name from `btrdb4-python` to `btrdb-python`.

Changes include
- update to docs config
- update to docs content 
- update to setup files
- update to readme