### PR TITLE
Updates `BTrDB.info()` to return a dict

### DIFF
--- a/btrdb/conn.py
+++ b/btrdb/conn.py
@@ -159,7 +159,7 @@ class BTrDB(object):
         Returns
         -------
         Stream
-            A Stream class object.
+            instance of Stream class or None
 
         """
         return Stream(self, to_uuid(uuid))
@@ -176,7 +176,7 @@ class BTrDB(object):
         Returns
         -------
         Stream
-            a Stream class object
+            instance of Stream class
         """
 
         if tags is None:
@@ -200,11 +200,16 @@ class BTrDB(object):
 
         Returns
         -------
-        InfoResponse
-            An object containing server connection and status information
+        dict
+            server connection and status information
 
         """
-        return self.ep.info()
+        info = self.ep.info()
+        return {
+            "majorVersion": info.majorVersion,
+            "build": info.build,
+            "proxy": { "proxyEndpoints": info.proxy.proxyEndpoints[0] },
+        }
 
     def streams_in_collection(self, collection, is_collection_prefix=True, tags=None, annotations=None):
         """

--- a/docs/source/api/conn.rst
+++ b/docs/source/api/conn.rst
@@ -1,0 +1,7 @@
+btrdb.conn
+=============
+
+.. automodule:: btrdb.conn
+
+.. autoclass:: BTrDB
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,6 +82,7 @@ API Reference
    :maxdepth: 2
 
    api/package
+   api/conn
    api/streams
    api/points
    api/exceptions

--- a/docs/source/working/server.rst
+++ b/docs/source/working/server.rst
@@ -55,8 +55,4 @@ method of the server object as shown below.
 
     conn = btrdb.connect()
     conn.info()
-    >> majorVersion: 5
-      build: "5.0.0"
-      proxy {
-          proxyEndpoints: "localhost:4410"
-      }
+    >> {'majorVersion': 5, 'build': '5.0.0', 'proxy': {'proxyEndpoints': '192.168.1.101:4410'}}

--- a/tests/btrdb/test_conn.py
+++ b/tests/btrdb/test_conn.py
@@ -20,7 +20,8 @@ import pytest
 from unittest.mock import Mock, PropertyMock
 
 from btrdb.conn import Connection, BTrDB
-
+from btrdb.endpoint import Endpoint
+from btrdb.grpcinterface import btrdb_pb2
 
 ##########################################################################
 ## Connection Tests
@@ -88,3 +89,22 @@ class TestBTrDB(object):
 
         streams = db.streams(uuid1, uuid2, versions=versions)
         assert streams._pinned_versions == expected
+
+    def test_info(self):
+        """
+        Assert info method returns a dict
+        """
+        serialized = b'\x18\x05*\x055.0.02\x10\n\x0elocalhost:4410'
+        info = btrdb_pb2.InfoResponse.FromString(serialized)
+
+        endpoint = Mock(Endpoint)
+        endpoint.info = Mock(return_value=info)
+        conn = BTrDB(endpoint)
+
+        truth = {
+            "majorVersion": 5,
+            "build": "5.0.0",
+            "proxy": { "proxyEndpoints": "localhost:4410", },
+        }
+
+        assert conn.info() == truth

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -22,6 +22,8 @@ import pytest
 from unittest.mock import Mock, PropertyMock
 from unittest.mock import patch
 
+from btrdb.conn import BTrDB
+from btrdb.endpoint import Endpoint
 from btrdb.stream import Stream, StreamSet, StreamFilter, INSERT_BATCH_SIZE
 from btrdb.point import RawPoint, StatPoint
 from btrdb.exceptions import BTrDBError, InvalidOperation
@@ -58,9 +60,6 @@ def stream2():
 ##########################################################################
 ## Stream Tests
 ##########################################################################
-
-from btrdb.conn import BTrDB
-from btrdb.endpoint import Endpoint
 
 class TestStream(object):
 


### PR DESCRIPTION
This PR changes `BTrDB.info()` to return a dict rather than the original `btrdb_pb2.InfoResponse`.

Also included:
- related tests
- updates to docs (including unrelated changes)
- adds missing docs file for API section