### PR TITLE
Adds helper for converting time spans to nanoseconds [ch72]

### DIFF
--- a/btrdb/utils/timez.py
+++ b/btrdb/utils/timez.py
@@ -36,7 +36,17 @@ def currently_as_ns():
 
 def ns_to_datetime(ns):
     """
-    Converts nanoseconds to a datetime object
+    Converts nanoseconds to a datetime object (UTC)
+
+    Parameters
+    ----------
+    ns : int
+        nanoseconds since epoch
+
+    Returns
+    -------
+    nanoseconds since epoch as a datetime object : datetime
+
     """
     dt = datetime.datetime.utcfromtimestamp(ns / 1e9)
     return dt.replace(tzinfo=pytz.utc)
@@ -44,7 +54,17 @@ def ns_to_datetime(ns):
 
 def datetime_to_ns(dt):
     """
-    Converts a datetime object nanoseconds
+    Converts a datetime object to nanoseconds since epoch.  If a timezone aware
+    object is received then it will be converted to UTC.
+
+    Parameters
+    ----------
+    dt : datetime
+
+    Returns
+    -------
+    nanoseconds : int
+
     """
     if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
         aware = pytz.utc.localize(dt)
@@ -56,7 +76,17 @@ def datetime_to_ns(dt):
 
 def to_nanoseconds(val):
     """
-    Converts datetime, datetime64, float, str (RFC 2822) to nanoseconds
+    Converts datetime, datetime64, float, str (RFC 2822) to nanoseconds.  If a
+    datetime-like object is received then nanoseconds since epoch is returned.
+
+    Parameters
+    ----------
+    val : datetime, datetime64, float, str
+        an object to convert to nanoseconds
+
+    Returns
+    -------
+    object converted to nanoseconds : int
     """
     if val is None or isinstance(val, int):
         return val
@@ -89,3 +119,45 @@ def to_nanoseconds(val):
             raise ValueError("can only convert whole numbers to nanoseconds")
 
     raise TypeError("only int, float, str, datetime, and datetime64 are allowed")
+
+
+def ns_delta(days=0, hours=0, minutes=0, seconds=0, milliseconds=0, microseconds=0):
+    """
+    Similar to `timedelta`, ns_delta represents a span of time but as
+    the total number of nanoseconds.
+
+    Parameters
+    ----------
+    days : int
+        days (as 24 hours) to convert to nanoseconds
+    hours : int
+        hours to convert to nanoseconds
+    minutes : int
+        minutes to convert to nanoseconds
+    seconds : int
+        seconds to convert to nanoseconds
+    milliseconds : int
+        milliseconds to convert to nanoseconds
+    microseconds : int
+        microseconds to convert to nanoseconds
+
+    Returns
+    -------
+    amount of time in nanoseconds : int
+
+    """
+    MICROSECOND = 1000
+    MILLESECOND = MICROSECOND * 1000
+    SECOND = MILLESECOND * 1000
+    MINUTE = SECOND * 60
+    HOUR = MINUTE * 60
+    DAY = HOUR * 24
+
+    ns = days * DAY
+    ns += hours * HOUR
+    ns += minutes * MINUTE
+    ns += seconds * SECOND
+    ns += milliseconds * MILLESECOND
+    ns += microseconds * MICROSECOND
+
+    return ns

--- a/btrdb/utils/timez.py
+++ b/btrdb/utils/timez.py
@@ -121,7 +121,8 @@ def to_nanoseconds(val):
     raise TypeError("only int, float, str, datetime, and datetime64 are allowed")
 
 
-def ns_delta(days=0, hours=0, minutes=0, seconds=0, milliseconds=0, microseconds=0):
+def ns_delta(days=0, hours=0, minutes=0, seconds=0, milliseconds=0, \
+             microseconds=0, nanoseconds=0):
     """
     Similar to `timedelta`, ns_delta represents a span of time but as
     the total number of nanoseconds.
@@ -140,6 +141,8 @@ def ns_delta(days=0, hours=0, minutes=0, seconds=0, milliseconds=0, microseconds
         milliseconds to convert to nanoseconds
     microseconds : int
         microseconds to convert to nanoseconds
+    nanoseconds : int
+        nanoseconds to add to the time span
 
     Returns
     -------
@@ -153,11 +156,11 @@ def ns_delta(days=0, hours=0, minutes=0, seconds=0, milliseconds=0, microseconds
     HOUR = MINUTE * 60
     DAY = HOUR * 24
 
-    ns = days * DAY
-    ns += hours * HOUR
-    ns += minutes * MINUTE
-    ns += seconds * SECOND
-    ns += milliseconds * MILLESECOND
-    ns += microseconds * MICROSECOND
+    nanoseconds += days * DAY
+    nanoseconds += hours * HOUR
+    nanoseconds += minutes * MINUTE
+    nanoseconds += seconds * SECOND
+    nanoseconds += milliseconds * MILLESECOND
+    nanoseconds += microseconds * MICROSECOND
 
-    return ns
+    return int(nanoseconds)

--- a/tests/btrdb/utils/test_timez.py
+++ b/tests/btrdb/utils/test_timez.py
@@ -22,7 +22,7 @@ import numpy as np
 from freezegun import freeze_time
 
 from btrdb.utils.timez import (currently_as_ns, datetime_to_ns, ns_to_datetime,
-                              to_nanoseconds)
+                              to_nanoseconds, ns_delta)
 
 
 ##########################################################################
@@ -166,3 +166,14 @@ class TestToNanoseconds(object):
 
         dt64 = np.datetime64('2018-01-01T12:00')
         assert expected == to_nanoseconds(dt64)
+
+
+class TestToNsDelta(object):
+
+    def test_ns_delta(self):
+        """
+        Assert ns_delta converts inputs properly
+        """
+        val = ns_delta(1,1,1,1,1,1)
+        assert val == int(1e3 + 1e6 + 1e9 + (1e9 * 60)  + (1e9 * 60 * 60) + \
+            (1e9 * 60 * 60 * 24) )

--- a/tests/btrdb/utils/test_timez.py
+++ b/tests/btrdb/utils/test_timez.py
@@ -174,6 +174,15 @@ class TestToNsDelta(object):
         """
         Assert ns_delta converts inputs properly
         """
-        val = ns_delta(1,1,1,1,1,1)
-        assert val == int(1e3 + 1e6 + 1e9 + (1e9 * 60)  + (1e9 * 60 * 60) + \
+        val = ns_delta(1,1,1,1,1,1,1)
+        assert val == int(1 + 1e3 + 1e6 + 1e9 + (1e9 * 60)  + (1e9 * 60 * 60) + \
             (1e9 * 60 * 60 * 24) )
+
+    def test_returns_int(self):
+        """
+        Assert ns_delta returns int if floats used for arguments
+        """
+        val = ns_delta(1.0,1.0,1.0,1.0,1.0,1.0,1.0)
+        assert val == int(1 + 1e3 + 1e6 + 1e9 + (1e9 * 60)  + (1e9 * 60 * 60) + \
+            (1e9 * 60 * 60 * 24) )
+        assert isinstance(val, int)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,4 @@ pytest-flakes==4.0.0
 freezegun==0.3.11
 
 # dependencies for conversions
-numpy
+numpy>=1.15

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,6 @@ pytest==4.0.2
 pytest-cov==2.6.0
 pytest-flakes==4.0.0
 freezegun==0.3.11
+
+# dependencies for conversions
+numpy


### PR DESCRIPTION
Adds a convenience method (similar to timedelta) that accepts hours, minutes, seconds, etc and returns the equivalent time in nanoseconds.

This PR also includes minor updates to comments in the same module.