### PR TITLE
Adds list_collections to BTrDB object

### DIFF
--- a/btrdb/conn.py
+++ b/btrdb/conn.py
@@ -211,6 +211,18 @@ class BTrDB(object):
             "proxy": { "proxyEndpoints": info.proxy.proxyEndpoints[0] },
         }
 
+    def list_collections(self, starts_with=""):
+        """
+        Returns a list of collection paths using the `starts_with` argument for
+        filtering.
+
+        Returns
+        -------
+        collection paths: list[str]
+
+        """
+        return [c for some in self.ep.listCollections(starts_with) for c in some]
+
     def streams_in_collection(self, collection, is_collection_prefix=True, tags=None, annotations=None):
         """
         Search for streams matching given parameters

--- a/btrdb/endpoint.py
+++ b/btrdb/endpoint.py
@@ -109,11 +109,18 @@ class Endpoint(object):
         result = self.stub.Create(params)
         BTrDBError.checkProtoStat(result.stat)
 
-    def listCollections(self, prefix, startingAt, limit):
-        params = btrdb_pb2.ListCollectionsParams(prefix = prefix, startWith = startingAt, limit = limit)
-        result = self.stub.ListCollections(params)
-        BTrDBError.checkProtoStat(result.stat)
-        return result.collections
+    def listCollections(self, prefix):
+        """
+        Returns a generator for windows of collection paths matching search
+
+        Yields
+        ------
+        collection paths : list[str]
+        """
+        params = btrdb_pb2.ListCollectionsParams(prefix=prefix)
+        for msg in self.stub.ListCollections(params):
+            BTrDBError.checkProtoStat(msg.stat)
+            yield msg.collections
 
     def lookupStreams(self, collection, isCollectionPrefix, tags, annotations):
         tagkvlist = []

--- a/tests/btrdb/test_conn.py
+++ b/tests/btrdb/test_conn.py
@@ -113,10 +113,10 @@ class TestBTrDB(object):
         Assert list_collections method works
         """
         endpoint = Mock(Endpoint)
-        endpoint.listCollections = Mock(side_effect=[[
+        endpoint.listCollections = Mock(side_effect=[iter([
             ['allen/automated'],
             ['allen/bindings']
-        ]])
+        ])])
         conn = BTrDB(endpoint)
 
         truth = ['allen/automated', 'allen/bindings']

--- a/tests/btrdb/test_conn.py
+++ b/tests/btrdb/test_conn.py
@@ -106,5 +106,18 @@ class TestBTrDB(object):
             "build": "5.0.0",
             "proxy": { "proxyEndpoints": "localhost:4410", },
         }
-
         assert conn.info() == truth
+
+    def test_list_collections(self):
+        """
+        Assert list_collections method works
+        """
+        endpoint = Mock(Endpoint)
+        endpoint.listCollections = Mock(side_effect=[[
+            ['allen/automated'],
+            ['allen/bindings']
+        ]])
+        conn = BTrDB(endpoint)
+
+        truth = ['allen/automated', 'allen/bindings']
+        assert conn.list_collections() == truth


### PR DESCRIPTION
Adds `list_collections` back into API after it mysteriously disappeared during recent refactor.