### PR TITLE
Enforces consistent exception handling in Stream methods [ch345]

### DIFF
--- a/btrdb/exceptions.py
+++ b/btrdb/exceptions.py
@@ -35,7 +35,7 @@ class BTrDBError(Exception):
         return self.code != 0
 
     def __repr__(self):
-        return "{4}({0}, {1}, {2})".format(repr(self.code), repr(self.msg), repr(self.mash), self.__class__.__name__)
+        return "{3}({0}, {1}, {2})".format(repr(self.code), repr(self.msg), repr(self.mash), self.__class__.__name__)
 
     def __str__(self):
         if self.isError():

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -206,7 +206,6 @@ class Stream(object):
             The version of the stream for the RawPoint supplied
 
         """
-        earliest = None
         start = 0
         return self.nearest(start, version=version, backward=False)
 
@@ -227,7 +226,6 @@ class Stream(object):
             the value was retrieved at.
 
         """
-        latest = None
         start = currently_as_ns()
         return self.nearest(start, version=version, backward=True)
 

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -208,17 +208,7 @@ class Stream(object):
         """
         earliest = None
         start = 0
-
-        # NOTE: left in for clarity but Stream.nearest has the same check
-        try:
-            earliest = self.nearest(start, version=version, backward=False)
-        except BTrDBError as exc:
-            if exc.code != 401:
-                raise
-            return None
-
-        return earliest
-
+        return self.nearest(start, version=version, backward=False)
 
     def latest(self, version=0):
         """
@@ -239,18 +229,7 @@ class Stream(object):
         """
         latest = None
         start = currently_as_ns()
-
-        # NOTE: left in for clarity but Stream.nearest has the same check
-        try:
-            latest = self.nearest(start, version=version, backward=True)
-        except BTrDBError as exc:
-            if exc.code != 401:
-                raise
-            return None
-
-        return latest
-
-
+        return self.nearest(start, version=version, backward=True)
 
     def tags(self, refresh=False):
         """


### PR DESCRIPTION
Forces `Stream.nearest`,  `Stream.latest`,  `Stream.earliest`, to suppress 401 errors and instead return `None`.  Adds to and improves existing tests for same.

Also includes minor fix for `BTrDBError.__repr__` and adds default to `backward` argument for `Stream.nearest`.