### PR TITLE
Modifies __repr__ and __str__ output [ch473]

### DIFF
--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -646,6 +646,9 @@ class Stream(object):
         """
         self._btrdb.ep.flush(self._uuid)
 
+    def __repr__(self):
+        return "<Stream collection={} name={}>".format(self.collection,
+            self.name)
 
 ##########################################################################
 ## StreamSet  Classes

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -70,6 +70,23 @@ class TestStream(object):
         Stream(None, "FAKE")
 
 
+    def test_repr_str(self):
+        """
+        Assert the repr and str output are correct
+        """
+        COLLECTION = "relay/foo"
+        NAME = "LINE222VA-ANG"
+        stream = Stream(None, "FAKE")
+        stream._collection = COLLECTION
+        stream._tags = {"name": NAME}
+
+        expected = "<Stream collection={} name={}>".format(
+            COLLECTION, NAME
+        )
+        assert stream.__repr__() == expected
+        assert stream.__str__() == expected
+
+
     def test_refresh_metadata(self):
         """
         Assert refresh_metadata calls Endpoint.streamInfo


### PR DESCRIPTION
Simple PR to fix the `__repr__` builtin method.  `__str__` is omitted as it calls `__repr__` by default.

The original issue calls for output similar to: `<Stream collection=FOO/SOMETHING name=LINE222-ANG>`

[ch473]