### PR TITLE
Fix StreamSet window methods [ch474]

### DIFF
--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -970,7 +970,29 @@ class StreamSetBase(object):
         """
         result = []
         params = self._params_from_filters()
-        stream_output_iterables = [s.values(**params) for s in self._streams]
+        versions = self.versions()
+
+        if self.pointwidth is not None:
+            # obtain list of stream.aligned_windows handles
+            stream_output_iterables = []
+            params.update({"pointwidth": self.pointwidth})
+            for s in self._streams:
+                params.update({"version": versions[s.uuid]})
+                stream_output_iterables.append(s.aligned_windows(**params))
+
+
+        elif None not in [self.width, self.depth]:
+            # obtain list of stream.windows handles
+            stream_output_iterables = []
+            params.update({"width": self.width, "depth": self.depth})
+            for s in self._streams:
+                params.update({"version": versions[s.uuid]})
+                stream_output_iterables.append(s.windows(**params))
+
+        else:
+            # obtain list of stream.windows handles
+            stream_output_iterables = [s.values(**params) for s in self._streams]
+
 
         for stream_output in stream_output_iterables:
             result.append([point[0] for point in stream_output])

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -926,8 +926,9 @@ class StreamSetBase(object):
                 data.append(s.aligned_windows(**params))
 
 
-        elif None not in [self.width, self.depth]:
-            # create list of stream.windows data
+        elif self.width is not None and self.depth is not None:
+            # create list of stream.windows data (the windows method should
+            # prevent the possibility that only one of these is None)
             params.update({"width": self.width, "depth": self.depth})
             for s in self._streams:
                 params.update({"version": versions[s.uuid]})

--- a/btrdb/utils/buffer.py
+++ b/btrdb/utils/buffer.py
@@ -17,8 +17,6 @@ Module for buffering utilities
 
 from collections import defaultdict
 
-from btrdb.point import RawPoint
-
 
 ##########################################################################
 ## Classes
@@ -34,9 +32,6 @@ class PointBuffer(defaultdict):
 
 
     def add_point(self, stream_index, point):
-        if not isinstance(point, RawPoint):
-            raise TypeError("Expected RawPoint instance")
-
         self.last_known_time[stream_index] = max(
             (self.last_known_time[stream_index] or -1), point.time
         )

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -910,8 +910,8 @@ class TestStreamSet(object):
 
         # assert expected output
         expected = [
-            [StatPoint.from_proto(window1[0][0][0])],
-            [StatPoint.from_proto(window2[0][0][0])],
+            [StatPoint(1, 2.0, 3.0, 4.0, 5, 6.0)],
+            [StatPoint(2, 3.0, 4.0, 5.0, 6, 7.0)],
         ]
         assert values == expected
 
@@ -1024,8 +1024,8 @@ class TestStreamSet(object):
 
         # assert expected output
         expected = [
-            [StatPoint.from_proto(window1[0][0][0])],
-            [StatPoint.from_proto(window2[0][0][0])],
+            [StatPoint(1, 2.0, 3.0, 4.0, 5, 6.0)],
+            [StatPoint(2, 3.0, 4.0, 5.0, 6, 7.0)],
         ]
         assert values == expected
 


### PR DESCRIPTION
Adds functionality to `values` and `rows` so they properly handle windowing calls.  Adds related tests.