### PR TITLE
Adds new and modifies existing magic methods to StreamSet [ch483]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ clean:
 	find . -name ".DS_Store" -print0 | xargs -0 rm -rf
 	-rm -rf docs/build
 	-rm -rf htmlcov
+	-rm -rf .pytest_cache
 	-rm -rf .coverage
 	-rm -rf build
 	-rm -rf dist

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -17,6 +17,7 @@ Module for Stream and related classes
 
 import uuid as uuidlib
 from copy import deepcopy
+from collections.abc import Sequence
 
 from btrdb.point import RawPoint, StatPoint
 from btrdb.transformers import StreamSetTransformer
@@ -654,7 +655,7 @@ class Stream(object):
 ## StreamSet  Classes
 ##########################################################################
 
-class StreamSetBase(object):
+class StreamSetBase(Sequence):
     """
     A lighweight wrapper around a list of stream objects
     """
@@ -979,10 +980,6 @@ class StreamSetBase(object):
             result.append([point[0] for point in stream_output])
 
         return result
-
-    def __iter__(self):
-        for stream in self._streams:
-            yield stream
 
     def __repr__(self):
         token = "stream" if len(self) == 1 else "streams"

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -985,10 +985,22 @@ class StreamSetBase(object):
             yield stream
 
     def __repr__(self):
-        return "<{}({} streams)>".format(self.__class__.__name__, len(self._streams))
+        token = "stream" if len(self) == 1 else "streams"
+        return "<{}({} {})>".format(
+            self.__class__.__name__, len(self._streams), token
+        )
 
     def __str__(self):
-        return "{} with {} streams".format(self.__class__.__name__, len(self._streams))
+        token = "stream" if len(self) == 1 else "streams"
+        return "{} with {} {}".format(
+            self.__class__.__name__, len(self._streams), token
+        )
+
+    def __getitem__(self, item):
+        return self._streams[item]
+
+    def __len__(self):
+        return len(self._streams)
 
 
 class StreamSet(StreamSetBase, StreamSetTransformer):

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -620,6 +620,69 @@ class TestStreamSet(object):
 
 
     ##########################################################################
+    ## builtin / magic methods tests
+    ##########################################################################
+
+    def test_subscriptable(self):
+        """
+        Assert StreamSet instance is subscriptable
+        """
+        data = [11,22,"dog","cat"]
+        streams = StreamSet(data)
+        for index, val in enumerate(data):
+            assert streams[index] == val
+
+
+    def test_len(self):
+        """
+        Assert StreamSet instance support len
+        """
+        data = [11,22,"dog","cat"]
+        streams = StreamSet(data)
+        assert len(streams) == len(data)
+
+
+    def test_iter(self):
+        """
+        Assert StreamSet instance support iteration
+        """
+        data = [11,22,"dog","cat"]
+        streams = StreamSet(data)
+        for index, stream in enumerate(streams):
+            assert data[index] == stream
+
+
+    def test_repr(self):
+        """
+        Assert StreamSet instance repr output
+        """
+        data = [11,22,"dog","cat"]
+        streams = StreamSet(data)
+        expected = "<StreamSet(4 streams)>"
+        assert streams.__repr__() == expected
+
+        data = [1]
+        streams = StreamSet(data)
+        expected = "<StreamSet(1 stream)>"
+        assert streams.__repr__() == expected
+
+
+    def test_str(self):
+        """
+        Assert StreamSet instance str output
+        """
+        data = [11,22,"dog","cat"]
+        streams = StreamSet(data)
+        expected = "StreamSet with 4 streams"
+        assert str(streams) == expected
+
+        data = [1]
+        streams = StreamSet(data)
+        expected = "StreamSet with 1 stream"
+        assert str(streams) == expected
+
+
+    ##########################################################################
     ## allow_window tests
     ##########################################################################
 

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -623,6 +623,36 @@ class TestStreamSet(object):
     ## builtin / magic methods tests
     ##########################################################################
 
+    def test_repr(self):
+        """
+        Assert StreamSet instance repr output
+        """
+        data = [11,22,"dog","cat"]
+        streams = StreamSet(data)
+        expected = "<StreamSet(4 streams)>"
+        assert streams.__repr__() == expected
+
+        data = [1]
+        streams = StreamSet(data)
+        expected = "<StreamSet(1 stream)>"
+        assert streams.__repr__() == expected
+
+
+    def test_str(self):
+        """
+        Assert StreamSet instance str output
+        """
+        data = [11,22,"dog","cat"]
+        streams = StreamSet(data)
+        expected = "StreamSet with 4 streams"
+        assert str(streams) == expected
+
+        data = [1]
+        streams = StreamSet(data)
+        expected = "StreamSet with 1 stream"
+        assert str(streams) == expected
+
+
     def test_subscriptable(self):
         """
         Assert StreamSet instance is subscriptable
@@ -652,34 +682,31 @@ class TestStreamSet(object):
             assert data[index] == stream
 
 
-    def test_repr(self):
+    def test_contains(self):
         """
-        Assert StreamSet instance repr output
-        """
-        data = [11,22,"dog","cat"]
-        streams = StreamSet(data)
-        expected = "<StreamSet(4 streams)>"
-        assert streams.__repr__() == expected
-
-        data = [1]
-        streams = StreamSet(data)
-        expected = "<StreamSet(1 stream)>"
-        assert streams.__repr__() == expected
-
-
-    def test_str(self):
-        """
-        Assert StreamSet instance str output
+        Assert StreamSet instance supports contains
         """
         data = [11,22,"dog","cat"]
         streams = StreamSet(data)
-        expected = "StreamSet with 4 streams"
-        assert str(streams) == expected
+        assert "dog" in streams
 
-        data = [1]
+
+    def test_reverse(self):
+        """
+        Assert StreamSet instance supports reversal
+        """
+        data = [11,22,"dog","cat"]
         streams = StreamSet(data)
-        expected = "StreamSet with 1 stream"
-        assert str(streams) == expected
+        assert list(reversed(streams)) == list(reversed(data))
+
+
+    def test_to_list(self):
+        """
+        Assert StreamSet instance cast to list
+        """
+        data = [11,22,"dog","cat"]
+        streams = StreamSet(data)
+        assert list(streams) == data
 
 
     ##########################################################################


### PR DESCRIPTION
Adds `__getitem__` and `__len__` magic methods to the StreamSet class while having it inherit from `abc.Sequence` to get related features.  StreamSet instances are now subscriptable and support `len`, `in`, `reversed`, etc.

Also added `-rm -rf .pytest_cache` to `make clean` in an unrelated change.