### PR TITLE
Modifies to_series transformer [ch645]

### DIFF
--- a/btrdb/transformers.py
+++ b/btrdb/transformers.py
@@ -40,9 +40,16 @@ def _stream_names(stream_set):
 ## Transform Functions
 ##########################################################################
 
-def to_series(stream_set):
+def to_series(stream_set, datetime64_index=True):
     """
     Returns a list of Pandas Series objects indexed by time
+
+    Parameters
+    ----------
+    datetime64_index: bool
+        Directs function to convert Series index to np.datetime64[ns] or
+        leave as np.int64.
+
     """
     try:
         import pandas as pd
@@ -50,12 +57,20 @@ def to_series(stream_set):
         raise ImportError("Please install Pandas to use this transformation function.")
 
     result = []
-    for output in stream_set.values():
+    stream_names = _stream_names(stream_set)
+
+    for idx, output in enumerate(stream_set.values()):
         times, values = [], []
         for item in output:
             times.append(item.time)
             values.append(item.value)
-        result.append(pd.Series(data=values, index=times))
+
+        if datetime64_index:
+            times = pd.Index(times, dtype='datetime64[ns]')
+
+        result.append(pd.Series(
+            data=values, index=times, name=stream_names[idx]
+        ))
     return result
 
 def to_dataframe(stream_set, columns=None):

--- a/tests/btrdb/test_transformers.py
+++ b/tests/btrdb/test_transformers.py
@@ -151,14 +151,35 @@ class TestTransformers(object):
             assert (result[idx] == expected["to_array"][idx]).all()
 
     def test_to_series(self, streamset):
+        """
+        Asserts to_series produces correct results including series name
+        """
         expected = []
+        expected_names = [s.collection + "/" + s.name for s in streamset]
         for points in streamset.values():
             values, times = list(zip(*[(p.value, p.time) for p in points]))
             expected.append(Series(values, times))
 
         result = to_series(streamset)
         for idx in range(4):
-            assert (result[idx] == expected[idx]).all()
+            assert (result[idx] == expected[idx]).all()     # verify data
+            assert result[idx].name == expected_names[idx]  # verify name
+
+    def test_to_series_index_type(self, streamset):
+        """
+        assert default index type is 'datetime64[ns]'
+        """
+        result = to_series(streamset)
+        for series in result:
+            assert series.index.dtype.name == 'datetime64[ns]'
+
+    def test_to_series_index_as_int(self, streamset):
+        """
+        assert datetime64_index: False produces 'int64' index
+        """
+        result = to_series(streamset, False)
+        for series in result:
+            assert series.index.dtype.name == 'int64'
 
     def test_to_dataframe(self, streamset):
         columns = ["time", "test/stream0", "test/stream1", "test/stream2", "test/stream3"]

--- a/tests/btrdb/test_transformers.py
+++ b/tests/btrdb/test_transformers.py
@@ -21,7 +21,7 @@ from io import StringIO, BytesIO
 import pytest
 from unittest.mock import Mock, PropertyMock
 import numpy as np
-from pandas import Series, DataFrame
+from pandas import Series, DataFrame, Index
 
 from btrdb.stream import Stream, StreamSet
 from btrdb.point import RawPoint
@@ -158,6 +158,7 @@ class TestTransformers(object):
         expected_names = [s.collection + "/" + s.name for s in streamset]
         for idx, points in enumerate(streamset.values()):
             values, times = list(zip(*[(p.value, p.time) for p in points]))
+            times = Index(times, dtype='datetime64[ns]')
             expected.append(Series(values, times, name=expected_names[idx]))
 
         result = to_series(streamset)

--- a/tests/btrdb/test_transformers.py
+++ b/tests/btrdb/test_transformers.py
@@ -156,9 +156,9 @@ class TestTransformers(object):
         """
         expected = []
         expected_names = [s.collection + "/" + s.name for s in streamset]
-        for points in streamset.values():
+        for idx, points in enumerate(streamset.values()):
             values, times = list(zip(*[(p.value, p.time) for p in points]))
-            expected.append(Series(values, times))
+            expected.append(Series(values, times, name=expected_names[idx]))
 
         result = to_series(streamset)
         for idx in range(4):


### PR DESCRIPTION
Adds ability to choose Series index as int64 or datetime64 through boolean argument.  Adds name to series using stream collection/name.  Makes datetime64[ns] the default index dtype.