### PR TITLE
Removes RepeatedScalarContainer from `info()` output [ch695]

### DIFF
--- a/btrdb/conn.py
+++ b/btrdb/conn.py
@@ -208,7 +208,7 @@ class BTrDB(object):
         return {
             "majorVersion": info.majorVersion,
             "build": info.build,
-            "proxy": { "proxyEndpoints": info.proxy.proxyEndpoints },
+            "proxy": { "proxyEndpoints": [ep for ep in info.proxy.proxyEndpoints] },
         }
 
     def list_collections(self, starts_with=""):

--- a/tests/btrdb/test_conn.py
+++ b/tests/btrdb/test_conn.py
@@ -106,7 +106,11 @@ class TestBTrDB(object):
             "build": "5.0.0",
             "proxy": { "proxyEndpoints": ["localhost:4410"], },
         }
-        assert conn.info() == truth
+        info = conn.info()
+        assert info == truth
+
+        # verify RepeatedScalarContainer is converted to list
+        assert info["proxy"]["proxyEndpoints"].__class__ == list
 
     def test_list_collections(self):
         """


### PR DESCRIPTION
Removes `RepeatedScalarContainer` from output of `conn.info()`.  Replaces with a list of string.

Using my serialized version of an `InfoResponse` it appears to test well.  Current version of v5 leaves this blank and it is expected to go away soon. (`b'\x18\x05*\x055.0.02\x10\n\x0elocalhost:4410'`)

According to protobuff file, the proxy object contains a repeated string so code should work fine though I couldnt test against a live server.

```
message ProxyInfo {
  repeated string proxyEndpoints = 1;
}
```