### PR TITLE
Adds StreamSet support for UUID lookup using __getitem__

### DIFF
--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -1103,6 +1103,15 @@ class StreamSetBase(Sequence):
         )
 
     def __getitem__(self, item):
+        if isinstance(item, str):
+            item = uuidlib.UUID(item)
+
+        if isinstance(item, uuidlib.UUID):
+            for stream in self._streams:
+                if stream.uuid == item:
+                    return stream
+            raise KeyError("Stream with uuid `{}` not found.".format(str(item)))
+
         return self._streams[item]
 
     def __len__(self):

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -690,6 +690,45 @@ class TestStreamSet(object):
             assert data[index] == stream
 
 
+    def test_indexing(self):
+        """
+        Assert StreamSet instance supports indexing
+        """
+        data = [11,22,"dog","cat"]
+        streams = StreamSet(data)
+
+        # verify index lookup
+        assert streams[-1] == data[-1]
+        for idx in range(len(streams)):
+            assert data[idx] == streams[idx]
+
+        # verify slicing works
+        assert streams[:2] == data[:2]
+
+
+    def test_mapping(self):
+        """
+        Assert StreamSet instance support key mapping
+        """
+        uuids = [uuid.uuid4() for _ in range(4)]
+        data = [Stream(None, uu) for uu in uuids]
+        streams = StreamSet(data)
+
+        # verify lookup with UUID
+        for uu in uuids:
+            assert streams[uu].uuid == uu
+
+        # verify lookup with str
+        for uu in uuids:
+            assert streams[str(uu)].uuid == uu
+
+        # verify raises KeyError
+        missing = uuid.uuid4()
+        with pytest.raises(KeyError) as e:
+            streams[missing]
+        assert str(missing) in str(e)
+
+
     def test_contains(self):
         """
         Assert StreamSet instance supports contains


### PR DESCRIPTION
Allows both UUID and str(UUID) as arguments for key lookup,  If not UUID or str it falls back to normal index lookup.

ch959