### PR TITLE
Adds profile support 

### DIFF
--- a/btrdb/__init__.py
+++ b/btrdb/__init__.py
@@ -56,7 +56,7 @@ def connect(conn_str=None, apikey=None, profile=None):
     profile: str, default=None
         The name of a profile containing the required connection information as
         found in the user's predictive grid credentials file
-        `~/.predictivegrid/credentials.yml`.
+        `~/.predictivegrid/credentials.yaml`.
 
     Returns
     -------

--- a/btrdb/__init__.py
+++ b/btrdb/__init__.py
@@ -18,9 +18,10 @@ Package for the btrdb database library.
 import os
 from btrdb.conn import Connection, BTrDB
 from btrdb.endpoint import Endpoint
-from btrdb.exceptions import ConnectionError
+from btrdb.exceptions import ConnectionError, CredentialsFileNotFound, \
+    ProfileNotFound
 from btrdb.version import get_version
-
+from btrdb.utils.credentials import load_profile
 
 ##########################################################################
 ## Module Variables
@@ -30,12 +31,16 @@ __version__ = get_version()
 
 BTRDB_ENDPOINTS = "BTRDB_ENDPOINTS"
 BTRDB_API_KEY = "BTRDB_API_KEY"
+BTRDB_PROFILE = "BTRDB_PROFILE"
 
 ##########################################################################
 ## Functions
 ##########################################################################
 
-def connect(conn_str=None, apikey=None):
+def _connect(conn_str=None, apikey=None):
+    return BTrDB(Endpoint(Connection(conn_str, apikey=apikey).channel))
+
+def connect(conn_str=None, apikey=None, profile=None):
     """
     Connect to a BTrDB server.
 
@@ -43,11 +48,15 @@ def connect(conn_str=None, apikey=None):
     ----------
     conn_str: str, default=None
         The address and port of the cluster to connect to, e.g. `192.168.1.1:4411`.
-        If set to None will look up the string from the environment variable
-        $BTRDB_ENDPOINTS (recommended).
+        If set to None, will look in the environment variable `$BTRDB_ENDPOINTS`
+        (recommended).
     apikey: str, default=None
         The API key used to authenticate requests (optional). If None, the key
-        is looked up from the environment variable $BTRDB_API_KEY.
+        is looked up from the environment variable `$BTRDB_API_KEY`.
+    profile: str, default=None
+        The name of a profile containing the required connection information as
+        found in the user's predictive grid credentials file
+        `~/.predictivegrid/credentials.yml`.
 
     Returns
     -------
@@ -55,13 +64,39 @@ def connect(conn_str=None, apikey=None):
         An instance of the BTrDB context to directly interact with the database.
 
     """
-    if not conn_str:
-        conn_str = os.environ.get(BTRDB_ENDPOINTS, None)
+    # Check function arguments
 
-    if not conn_str:
-        raise ConnectionError("Connection string not supplied and no ENV variable found.")
+    if conn_str and profile:
+        raise ValueError("Received both conn_str and profile arguments.")
 
-    if not apikey:
-        apikey = os.environ.get(BTRDB_API_KEY, default=None)
+    if profile:
+        credentials = load_profile(profile)
+        return _connect(credentials["endpoints"], credentials["api_key"])
 
-    return BTrDB(Endpoint(Connection(conn_str, apikey=apikey).channel))
+    if conn_str:
+        return _connect(conn_str, apikey)
+
+    # Check ENV variables
+
+    keys = os.environ.keys()
+    if BTRDB_PROFILE in keys and BTRDB_ENDPOINTS in keys:
+        raise ValueError("Found both BTRDB_PROFILE and BTRDB_ENDPOINTS in ENV. "
+            "Only one is allowed.")
+
+    if BTRDB_PROFILE in keys:
+        credentials = load_profile(os.environ[BTRDB_PROFILE])
+        return _connect(credentials["endpoints"], credentials["api_key"])
+
+    if BTRDB_ENDPOINTS in keys:
+        return _connect(os.environ[BTRDB_ENDPOINTS], os.environ.get(BTRDB_API_KEY, None))
+
+
+    # Attempt default profile (no arguments or ENV found)
+
+    try:
+        credentials = load_profile("default")
+        return _connect(credentials["endpoints"], credentials["api_key"])
+    except (CredentialsFileNotFound, ProfileNotFound):
+        pass
+
+    raise ConnectionError("Could not determine credentials to use.")

--- a/btrdb/exceptions.py
+++ b/btrdb/exceptions.py
@@ -73,3 +73,15 @@ class BTRDBTypeError(TypeError):
     A problem interacting with the BTrDB server.
     """
     pass
+
+class CredentialsFileNotFound(FileNotFoundError):
+    """
+    The credentials file could not be found.
+    """
+    pass
+
+class ProfileNotFound(Exception):
+    """
+    A requested profile could not be found in the credentials file.
+    """
+    pass

--- a/btrdb/utils/credentials.py
+++ b/btrdb/utils/credentials.py
@@ -1,5 +1,5 @@
 # btrdb.utils.credentials
-# Package for the btrdb database library.
+# Package for interacting with the PredictiveGrid credentials file.
 #
 # Author:   PingThings
 # Created:  Thu May 09 11:36:53 2019 -0400
@@ -8,7 +8,7 @@
 # ID: credentials.py [] allen@pingthings.io $
 
 """
-Package for the btrdb database library.
+Package for interacting with the PredictiveGrid credentials file.
 """
 
 ##########################################################################

--- a/btrdb/utils/credentials.py
+++ b/btrdb/utils/credentials.py
@@ -25,7 +25,7 @@ from btrdb.exceptions import ProfileNotFound, CredentialsFileNotFound
 ##########################################################################
 
 CONFIG_DIR = ".predictivegrid"
-CREDENTIALS_FILENAME = "credentials.yml"
+CREDENTIALS_FILENAME = "credentials.yaml"
 
 
 ##########################################################################
@@ -69,7 +69,7 @@ def load_profile(name="default"):
     Raises
     ------
     CredentialsFileNotFound
-        The expected credentials file `~/.predictivegrid/credentials.yml` could not be found.
+        The expected credentials file `~/.predictivegrid/credentials.yaml` could not be found.
 
     ProfileNotFound
         The requested profile could not be found in the credentials file

--- a/btrdb/utils/credentials.py
+++ b/btrdb/utils/credentials.py
@@ -1,0 +1,80 @@
+# btrdb.utils.credentials
+# Package for the btrdb database library.
+#
+# Author:   PingThings
+# Created:  Thu May 09 11:36:53 2019 -0400
+#
+# For license information, see LICENSE.txt
+# ID: credentials.py [] allen@pingthings.io $
+
+"""
+Package for the btrdb database library.
+"""
+
+##########################################################################
+## Imports
+##########################################################################
+
+import os
+import yaml
+
+from btrdb.exceptions import ProfileNotFound, CredentialsFileNotFound
+
+##########################################################################
+## Module Variables
+##########################################################################
+
+CONFIG_DIR = ".predictivegrid"
+CREDENTIALS_FILENAME = "credentials.yml"
+
+
+##########################################################################
+## Functions
+##########################################################################
+
+def _credentials_path():
+    return os.path.join(os.environ["HOME"], CONFIG_DIR, CREDENTIALS_FILENAME)
+
+def load_credentials():
+    """
+    Returns a dict of the credentials file contents
+
+    Returns
+    -------
+    dict
+        A dictionary of profile connection information
+    """
+    path = _credentials_path()
+    try:
+        with open(path, 'r') as stream:
+            return yaml.safe_load(stream)
+    except FileNotFoundError as exc:
+        raise CredentialsFileNotFound("Cound not find `{}`".format(path)) from exc
+
+def load_profile(name="default"):
+    """
+    Returns the BTrDB connection information (as dict) for a requested profile
+    from the user's credentials file.
+
+    Parameters
+    ----------
+    name: str
+        The name of the profile to retrieve
+
+    Returns
+    -------
+    dict
+        A dictionary of the requested profile's connection information
+
+    Raises
+    ------
+    CredentialsFileNotFound
+        The expected credentials file `~/.predictivegrid/credentials.yml` could not be found.
+
+    ProfileNotFound
+        The requested profile could not be found in the credentials file
+    """
+    credentials = load_credentials()
+    if name not in credentials.keys():
+        raise ProfileNotFound("Profile `{}` not found in credentials file.".format(name))
+    return credentials[name]["btrdb"]

--- a/docs/source/working/server.rst
+++ b/docs/source/working/server.rst
@@ -8,7 +8,7 @@ use as well as the access port.
 By default BTrDB servers expose port 4410 for unencrypted access and 4411 for
 encrypted access using TLS.  You may also opt for authentication using an API key
 which can be provided to you by the BTrDB server administrators.  Using such a
-key will require the TLS port (4411) and attempting to use a different port with
+key will require the TLS port (4411) as attempting to use a different port with
 an API key will raise an exception.
 
 Connecting to servers
@@ -43,6 +43,36 @@ Several connection options are shown in the code below:
     # connect with API key
     conn = btrdb.connect("192.168.1.101:4411", apikey="123456789123456789")
 
+Using Profiles
+~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to providing the endpoint and API key directly (or through environment
+variables), you may provide a profile name which looks into your PredictiveGrid
+credentials file at `$HOME/.predictivegrid/credentials.yml`.  Using profiles
+is meant as a (optional) convenience device and may also be supplied through
+the environmental variable `$BTRDB_PROFILE`.
+
+.. code-block:: python
+
+    import btrdb
+
+    # connect using your own "research" profile
+    conn = btrdb.connect(profile="research")
+
+The credentials file is in YAML format as shown below.
+
+.. code-block:: yaml
+
+    research:
+      name: "research"
+      btrdb:
+        endpoints: "research.example.com:4411"
+        api_key: "d976a2d61103feb2235441fd6887955c"
+    default:
+      name: "default"
+      btrdb:
+        endpoints: "btrdb.example.com:4411"
+        api_key: "e666a2d61103feb2235441fd68879440"
 
 
 Viewing server status

--- a/docs/source/working/server.rst
+++ b/docs/source/working/server.rst
@@ -48,7 +48,7 @@ Using Profiles
 
 In addition to providing the endpoint and API key directly (or through environment
 variables), you may provide a profile name which looks into your PredictiveGrid
-credentials file at `$HOME/.predictivegrid/credentials.yml`.  Using profiles
+credentials file at `$HOME/.predictivegrid/credentials.yaml`.  Using profiles
 is meant as a (optional) convenience device and may also be supplied through
 the environmental variable `$BTRDB_PROFILE`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ grpcio-tools==1.16.1
 
 # Time related utils
 pytz
+
+# Misc libraries
+pyyaml

--- a/tests/btrdb/utils/test_credentials.py
+++ b/tests/btrdb/utils/test_credentials.py
@@ -29,7 +29,7 @@ from btrdb.utils.credentials import *
 
 class TestLoadCredentials(object):
 
-    @patch('btrdb.utils.credentials.open')
+    @patch('builtins.open')
     def test_raises_err_if_credentials_not_found(self, mock_open):
         """
         Assert CredentialsFileNotFound is raised if credentials.yaml is not found

--- a/tests/btrdb/utils/test_credentials.py
+++ b/tests/btrdb/utils/test_credentials.py
@@ -1,0 +1,92 @@
+# tests.test_credentials
+# Testing for the btrdb.utils.credentials module
+#
+# Author:   PingThings
+# Created:  Thu May 09 14:29:21 2019 -0400
+#
+# For license information, see LICENSE.txt
+# ID: test_credentials.py [] allen@pingthings.io $
+
+"""
+Testing for the btrdb.utils.credentials
+"""
+
+##########################################################################
+## Imports
+##########################################################################
+
+import pytest
+from unittest.mock import Mock, patch
+
+from btrdb.exceptions import *
+from btrdb.utils.credentials import *
+
+
+##########################################################################
+## Tests
+##########################################################################
+
+
+class TestLoadCredentials(object):
+
+    @patch('btrdb.utils.credentials.open')
+    def test_raises_err_if_credentials_not_found(self, mock_open):
+        """
+        Assert CredentialsFileNotFound is raised if credentials.yaml is not found
+        """
+        mock_open.side_effect = FileNotFoundError("foo")
+        with pytest.raises(CredentialsFileNotFound):
+            load_credentials()
+
+
+class TestLoadProfile(object):
+
+    @patch('btrdb.utils.credentials.load_credentials')
+    def test_raises_err_if_profile_not_found(self, mock_credentials):
+        """
+        Assert ProfileNotFound is raised if profile is asked for but not found
+        """
+        mock_credentials.return_value = {
+            "duck": {
+                "btrdb" : {
+                    "endpoints": "192.168.1.100:4410",
+                    "api_key": "111222333",
+                }
+            }
+        }
+        with pytest.raises(ProfileNotFound):
+            load_profile("horse")
+
+    @patch('btrdb.utils.credentials.load_credentials')
+    def test_returns_requested_profile(self, mock_credentials):
+        """
+        Assert returns correct profile
+        """
+        mock_credentials.return_value = {
+            "default": {"btrdb": {"endpoints": "default"}},
+            "duck": {"btrdb": {"endpoints": "duck"}},
+        }
+        assert load_profile("duck")["endpoints"] == "duck"
+
+    @patch('btrdb.utils.credentials.load_credentials')
+    def test_returns_default_profile(self, mock_credentials):
+        """
+        Assert default profile is returned
+        """
+        mock_credentials.return_value = {
+            "duck": {
+                "btrdb" : {
+                    "endpoints": "192.168.1.100:4411",
+                    "api_key": "111222333",
+                },
+                "name": "duck"
+            },
+            "default": {
+                "btrdb" : {
+                    "endpoints": "192.168.1.222:4411",
+                    "api_key": "333222111",
+                },
+                "name": "default"
+            },
+        }
+        assert load_profile()["api_key"] == "333222111"

--- a/tests/btrdb/utils/test_credentials.py
+++ b/tests/btrdb/utils/test_credentials.py
@@ -8,7 +8,7 @@
 # ID: test_credentials.py [] allen@pingthings.io $
 
 """
-Testing for the btrdb.utils.credentials
+Testing for the btrdb.utils.credentials module
 """
 
 ##########################################################################
@@ -16,7 +16,7 @@ Testing for the btrdb.utils.credentials
 ##########################################################################
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from btrdb.exceptions import *
 from btrdb.utils.credentials import *


### PR DESCRIPTION
Adds the ability to use profiles for connection information.  Profile data can be found in YAML format at `$HOME/.predictivegrid/credentials`.

The preference rules are as follows:

* if you pass in credentials and profile then RAISE. 
* if profile is passed use it.  RAISE exc if not found.
* look for profile and credentials in ENV.  if both are found then RAISE 
* otherwise use whichever.  RAISE if profile is used but not found.
* if NO args and NO ENVs then look for default profile and use it. 
* else RAISE

ch1288