### PR TITLE
Serializes annotation values to support nested structures

### DIFF
--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -86,6 +86,11 @@ class Stream(object):
         self._collection, self._property_version, self._tags, self._annotations, _ = ep.streamInfo(self._uuid, False, True)
         self._known_to_exist = True
 
+        # deserialize annoation values
+        self._annotations = dict(
+            [[k, json.loads(v)] for k, v in self._annotations.items()]
+        )
+
     def exists(self):
         """
         Check if stream exists

--- a/btrdb/utils/conversion.py
+++ b/btrdb/utils/conversion.py
@@ -18,6 +18,35 @@ Conversion utilities for btrdb
 ##########################################################################
 
 import uuid
+import json
+from datetime import datetime
+
+
+##########################################################################
+## Classes
+##########################################################################
+
+class AnnotationEncoder(json.JSONEncoder):
+    """Default JSON encoder class for saving stream annotations"""
+
+    def default(self, obj):
+        RFC3339 = "%Y-%m-%d %H:%M:%S.%f%z"
+
+        # handle Python datetime
+        if isinstance(obj, datetime):
+            return obj.strftime(RFC3339)
+
+        # handle numpy datetime64
+        try:
+            import numpy as np
+            if isinstance(obj, np.datetime64):
+                return obj.astype(datetime).strftime(RFC3339)
+        except ImportError:
+            pass
+
+        # Let the base class default method raise the TypeError
+        return json.JSONEncoder.default(self, obj)
+
 
 ##########################################################################
 ## Functions

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -108,6 +108,21 @@ class TestStream(object):
         stream._btrdb.ep.streamInfo.assert_called_once_with(uu, False, True)
 
 
+    def test_refresh_metadata_deserializes_annotations(self):
+        """
+        Assert refresh_metadata deserializes annotation values
+        """
+        uu = uuid.uuid4()
+        serialized = {"parent": '{"child": 42}'}
+        expected = {"parent": {"child": 42}}
+        endpoint = Mock(Endpoint)
+        endpoint.streamInfo = Mock(return_value=("koala", 42, {}, serialized, None))
+        stream = Stream(btrdb=BTrDB(endpoint), uuid=uu)
+
+        stream.refresh_metadata()
+        assert stream.annotations()[0] == expected
+
+
     ##########################################################################
     ## update tests
     ##########################################################################

--- a/tests/btrdb/utils/test_conversions.py
+++ b/tests/btrdb/utils/test_conversions.py
@@ -16,9 +16,12 @@ Testing for btrdb convertion utilities
 ##########################################################################
 
 import uuid
-import pytest
+from datetime import datetime
 
-from btrdb.utils.conversion import to_uuid
+import pytest
+import numpy as np
+
+from btrdb.utils.conversion import to_uuid, AnnotationEncoder
 
 ##########################################################################
 ## Test Constants
@@ -31,6 +34,17 @@ EXAMPLE_UUID = uuid.UUID(EXAMPLE_UUID_STR)
 ##########################################################################
 ## Initialization Tests
 ##########################################################################
+
+class TestAnnotationEncoder(object):
+
+    def test_datetime_conversions(self):
+        dt = datetime(2018,9,10,16,30)
+        expected = '"2018-09-10 16:30:00.000000"'
+        encoder = AnnotationEncoder()
+
+        assert encoder.encode(dt) == expected
+        assert encoder.encode(np.datetime64(dt)) == expected
+
 
 class TestToUUID(object):
 


### PR DESCRIPTION
JSON serializes annotation dict values to support nested structures.  Deserialization is automatically performed during `refresh_metadata`.

[ch952]