### PR TITLE
pointwidth helper utility

### DIFF
--- a/btrdb/endpoint.py
+++ b/btrdb/endpoint.py
@@ -42,7 +42,7 @@ class Endpoint(object):
             yield result.values, result.versionMajor
 
     def alignedWindows(self, uu, start, end, pointwidth, version = 0):
-        params = btrdb_pb2.AlignedWindowsParams(uuid = uu.bytes, start = start, end = end, versionMajor = version, pointWidth = pointwidth)
+        params = btrdb_pb2.AlignedWindowsParams(uuid = uu.bytes, start = start, end = end, versionMajor = version, pointWidth = int(pointwidth))
         for result in self.stub.AlignedWindows(params):
             BTrDBError.checkProtoStat(result.stat)
             yield result.values, result.versionMajor

--- a/btrdb/utils/general.py
+++ b/btrdb/utils/general.py
@@ -30,3 +30,154 @@ def unpack_stream_descriptor(desc):
     for ann in desc.annotations:
         anns[ann.key] = ann.val.value
     return tags, anns
+
+
+##########################################################################
+## Pointwidth Helpers
+##########################################################################
+
+class pointwidth(object):
+    """
+    A representation of a period of time described by the BTrDB tree (and used in
+    aligned_windows queries). The pointwidth allows users to traverse to different
+    levels of the BTrDB tree and to select StatPoints directly, vastly improving the
+    performance of queries. However, because the real duration of the pointwidth is
+    defined in powers of 2 (e.g. 2**pointwidth nanoseconds), the durations do not map
+    to human time periods (e.g. weeks or hours).
+
+    Parameters
+    ----------
+    p : int
+        cast an integer to the specified pointwidth
+    """
+
+    @classmethod
+    def from_timedelta(cls, delta):
+        """
+        Returns the closest pointwidth for the given timedelta without going over the
+        specified duration. Because pointwidths are in powers of 2, be sure to check
+        that the returned real duration is sufficient.
+        """
+        return cls.from_nanoseconds(delta.total_seconds()*1e9)
+
+    @classmethod
+    def from_nanoseconds(cls, nsec):
+        """
+        Returns the closest pointwidth for the given number of nanoseconds without going
+        over the specified duration. Because pointwidths are in powers of 2, be sure to
+        check that the returned real duration is sufficient.
+        """
+        for pos in range(62):
+            nsec = nsec >> 1
+            if nsec == 0:
+                break
+        return cls(pos)
+
+    def __init__(self, p):
+        self._pointwidth = int(p)
+
+    @property
+    def nanoseconds(self):
+        return 2**self._pointwidth
+
+    @property
+    def microseconds(self):
+        return self.nanoseconds / 1e3
+
+    @property
+    def milliseconds(self):
+        return self.nanoseconds / 1e6
+
+    @property
+    def seconds(self):
+        return self.nanoseconds / 1e9
+
+    @property
+    def minutes(self):
+        return self.nanoseconds / 6e10
+
+    @property
+    def hours(self):
+        return self.nanoseconds / 3.6e12
+
+    @property
+    def days(self):
+        return self.nanoseconds / 8.64e13
+
+    @property
+    def weeks(self):
+        return self.nanoseconds / 6.048e14
+
+    @property
+    def months(self):
+        return self.nanoseconds / 2.628e15
+
+    @property
+    def years(self):
+        return self.nanoseconds / 3.154e16
+
+    def decr(self):
+        return pointwidth(self-1)
+
+    def incr(self):
+        return pointwidth(self+1)
+
+    def __int__(self):
+        return self._pointwidth
+
+    def __eq__(self, other):
+        return int(self) == int(other)
+
+    def __lt__(self, other):
+        return int(self) < int(other)
+
+    def __le__(self, other):
+        return int(self) <= int(other)
+
+    def __gt__(self, other):
+        return int(self) > int(other)
+
+    def __ge__(self, other):
+        return int(self) >= int(other)
+
+    def __add__(self, other):
+        return pointwidth(int(self)+int(other))
+
+    def __sub__(self, other):
+        return pointwidth(int(self)-int(other))
+
+    def __str__(self):
+        """
+        Returns the pointwidth to the closest unit
+        """
+        if self >= 55:
+            return "{:0.2f} years".format(self.years)
+
+        if self >= 52:
+            return "{:0.2f} months".format(self.months)
+
+        if self >= 50:
+            return "{:0.2f} weeks".format(self.weeks)
+
+        if self >= 47:
+            return "{:0.2f} days".format(self.days)
+
+        if self >= 42:
+            return "{:0.2f} hours".format(self.hours)
+
+        if self >= 36:
+            return "{:0.2f} minutes".format(self.minutes)
+
+        if self >= 30:
+            return "{:0.2f} seconds".format(self.seconds)
+
+        if self >= 20:
+            return "{:0.2f} milliseconds".format(self.milliseconds)
+
+        if self >= 10:
+            return "{:0.2f} microseconds".format(self.microseconds)
+
+        return "{:0.0f} nanoseconds".format(self.nanoseconds)
+
+    def __repr__(self):
+        return "<pointwidth {}>".format(int(self))

--- a/tests/btrdb/utils/test_general.py
+++ b/tests/btrdb/utils/test_general.py
@@ -1,0 +1,110 @@
+# tests.test_general
+# Testing for the btrdb.utils.general module
+#
+# Author:   PingThings
+# Created:  Wed Jun 12 11:57:06 2019 -0400
+#
+# For license information, see LICENSE.txt
+# ID: test_collection.py [] benjamin@pingthings.io $
+
+"""
+Testing for the btrdb.utils.general module
+"""
+
+import pytest
+
+from datetime import timedelta
+from btrdb.utils.timez import ns_delta
+from btrdb.utils.general import pointwidth
+
+
+class TestPointwidth(object):
+
+    @pytest.mark.parametrize("delta, expected", [
+        (timedelta(days=365), 54),
+        (timedelta(days=30), 51),
+        (timedelta(days=7), 49),
+        (timedelta(days=1), 46),
+        (timedelta(hours=4), 45),
+        (timedelta(minutes=15), 40),
+        (timedelta(seconds=30), 29),
+    ])
+    def test_from_nanoseconds(self, delta, expected):
+        """
+        Test getting the closest point width from nanoseconds
+        """
+        assert pointwidth.from_nanoseconds(nsec) == expected
+
+    @pytest.mark.parametrize("nsec, expected", [
+        (ns_delta(days=365), 54),
+        (ns_delta(days=30), 51),
+        (ns_delta(days=7), 49),
+        (ns_delta(days=1), 46),
+        (ns_delta(hours=12), 45),
+        (ns_delta(minutes=30), 40),
+        (ns_delta(seconds=1), 29),
+    ])
+    def test_from_nanoseconds(self, nsec, expected):
+        """
+        Test getting the closest point width from nanoseconds
+        """
+        assert pointwidth.from_nanoseconds(nsec) == expected
+
+    def test_time_conversions(self):
+        """
+        Test standard pointwidth time conversions
+        """
+        assert pointwidth(62).years == pytest.approx(146.2171)
+        assert pointwidth(56).years == pytest.approx(2.2846415)
+        assert pointwidth(54).months == pytest.approx(6.854793)
+        assert pointwidth(50).weeks == pytest.approx(1.861606)
+        assert pointwidth(48).days == pytest.approx(3.2578122)
+        assert pointwidth(44).hours == pytest.approx(4.886718)
+        assert pointwidth(38).minutes == pytest.approx(4.581298)
+        assert pointwidth(32).seconds == pytest.approx(4.294967)
+        assert pointwidth(26).milliseconds == pytest.approx(67.108864)
+        assert pointwidth(14).microseconds == pytest.approx(16.384)
+        assert pointwidth(8).nanoseconds == pytest.approx(256)
+
+    def test_int_conversion(self):
+        """
+        Test converting a pointwidth into an int and back
+        """
+        assert int(pointwidth(42)) == 42
+        assert isinstance(int(pointwidth(32)), int)
+        assert isinstance(pointwidth(pointwidth(32)), pointwidth)
+
+    def test_equality(self):
+        """
+        Test equality comparision of pointwidth
+        """
+        assert pointwidth(32) == pointwidth(32)
+        assert 32 == pointwidth(32)
+        assert pointwidth(32) == 32.0000
+
+    def test_strings(self):
+        """
+        Test the string representation of pointwidth
+        """
+        assert "years" in str(pointwidth(55))
+        assert "months" in str(pointwidth(52))
+        assert "weeks" in str(pointwidth(50))
+        assert "days" in str(pointwidth(47))
+        assert "hours" in str(pointwidth(42))
+        assert "minutes" in str(pointwidth(36))
+        assert "seconds" in str(pointwidth(30))
+        assert "milliseconds" in str(pointwidth(20))
+        assert "microseconds" in str(pointwidth(10))
+        assert "nanoseconds" in str(pointwidth(5))
+
+    def test_decr(self):
+        """
+        Test decrementing a pointwidth
+        """
+        assert pointwidth(23).decr() == 22
+
+    def test_incr(self):
+        """
+        Test incrementing a pointwidth
+        """
+        assert pointwidth(23).incr() == 24


### PR DESCRIPTION
The `pointwidth` class is a helper utility to allow users to better evaluate pointwidth durations when working with `aligned_windows`. It can be constructed from an int (and behaves as an int) or it can be constructed from an `ns_delta` or `timedelta` for convenience. 