### PR TITLE
Fixes to_dataframe support for StatPoint [ch1705]

### DIFF
--- a/btrdb/transformers.py
+++ b/btrdb/transformers.py
@@ -29,10 +29,10 @@ def _get_time_from_row(row):
     raise Exception("Row contains no data")
 
 
-def _stream_names(stream_set):
+def _stream_names(streamset):
     return tuple(
         s.collection + "/" +  s.name \
-        for s in stream_set._streams
+        for s in streamset._streams
     )
 
 
@@ -40,7 +40,7 @@ def _stream_names(stream_set):
 ## Transform Functions
 ##########################################################################
 
-def to_series(stream_set, datetime64_index=True, agg="mean"):
+def to_series(streamset, datetime64_index=True, agg="mean"):
     """
     Returns a list of Pandas Series objects indexed by time
 
@@ -62,9 +62,9 @@ def to_series(stream_set, datetime64_index=True, agg="mean"):
         raise ImportError("Please install Pandas to use this transformation function.")
 
     result = []
-    stream_names = _stream_names(stream_set)
+    stream_names = _stream_names(streamset)
 
-    for idx, output in enumerate(stream_set.values()):
+    for idx, output in enumerate(streamset.values()):
         times, values = [], []
         for point in output:
             times.append(point.time)
@@ -82,7 +82,7 @@ def to_series(stream_set, datetime64_index=True, agg="mean"):
     return result
 
 
-def to_dataframe(stream_set, columns=None, agg="mean"):
+def to_dataframe(streamset, columns=None, agg="mean"):
     """
     Returns a Pandas DataFrame object indexed by time and using the values of a
     stream for each column.
@@ -103,14 +103,23 @@ def to_dataframe(stream_set, columns=None, agg="mean"):
     except ImportError:
         raise ImportError("Please install Pandas to use this transformation function.")
 
-    stream_names = _stream_names(stream_set)
+    stream_names = _stream_names(streamset)
     columns = columns if columns else ["time"] + list(stream_names)
-    return pd.DataFrame(to_dict(stream_set,agg=agg), columns=columns).set_index("time")
+    return pd.DataFrame(to_dict(streamset,agg=agg), columns=columns).set_index("time")
 
 
-def to_array(stream_set, agg="mean"):
+def to_array(streamset, agg="mean"):
     """
-    Returns a list of Numpy arrays (one per stream) containing point classes.
+    Returns a multidimensional numpy array (similar to a list of lists) containing point
+    classes.
+
+    Parameters
+    ----------
+    agg : str, default: "mean"
+        Specify the StatPoint field (e.g. aggregating function) to return for the
+        arrays. Must be one of "min", "mean", "max", "count", or "stddev". This
+        argument is ignored if RawPoint values are passed into the function.
+
     """
     try:
         import numpy as np
@@ -118,7 +127,7 @@ def to_array(stream_set, agg="mean"):
         raise ImportError("Please install Numpy to use this transformation function.")
 
     results = []
-    for points in stream_set.values():
+    for points in streamset.values():
         segment = []
         for point in points:
             if point.__class__.__name__ == "RawPoint":
@@ -129,7 +138,7 @@ def to_array(stream_set, agg="mean"):
     return np.array(results)
 
 
-def to_dict(stream_set, agg="mean"):
+def to_dict(streamset, agg="mean"):
     """
     Returns a list of OrderedDict for each time code with the appropriate
     stream data attached.
@@ -143,8 +152,8 @@ def to_dict(stream_set, agg="mean"):
 
     """
     data = []
-    stream_names = _stream_names(stream_set)
-    for row in stream_set.rows():
+    stream_names = _stream_names(streamset)
+    for row in streamset.rows():
         item = OrderedDict({
             "time": _get_time_from_row(row),
         })
@@ -157,7 +166,7 @@ def to_dict(stream_set, agg="mean"):
     return data
 
 
-def to_csv(stream_set, fobj, dialect=None, fieldnames=None, agg="mean"):
+def to_csv(streamset, fobj, dialect=None, fieldnames=None, agg="mean"):
     """
     Saves stream data as a CSV file.
 
@@ -194,17 +203,17 @@ def to_csv(stream_set, fobj, dialect=None, fieldnames=None, agg="mean"):
                 file_to_close.close()
 
     with open_path_or_file(fobj) as csvfile:
-        stream_names = _stream_names(stream_set)
+        stream_names = _stream_names(streamset)
         fieldnames = fieldnames if fieldnames else ["time"] + list(stream_names)
 
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames, dialect=dialect)
         writer.writeheader()
 
-        for item in to_dict(stream_set, agg=agg):
+        for item in to_dict(streamset, agg=agg):
             writer.writerow(item)
 
 
-def to_table(stream_set, agg="mean"):
+def to_table(streamset, agg="mean"):
     """
     Returns string representation of the data in tabular form using the tabulate
     library.
@@ -222,7 +231,7 @@ def to_table(stream_set, agg="mean"):
     except ImportError:
         raise ImportError("Please install tabulate to use this transformation function.")
 
-    return tabulate(stream_set.to_dict(agg=agg), headers="keys")
+    return tabulate(streamset.to_dict(agg=agg), headers="keys")
 
 
 ##########################################################################

--- a/btrdb/transformers.py
+++ b/btrdb/transformers.py
@@ -40,7 +40,7 @@ def _stream_names(stream_set):
 ## Transform Functions
 ##########################################################################
 
-def to_series(stream_set, datetime64_index=True):
+def to_series(stream_set, datetime64_index=True, agg="mean"):
     """
     Returns a list of Pandas Series objects indexed by time
 
@@ -49,6 +49,11 @@ def to_series(stream_set, datetime64_index=True):
     datetime64_index: bool
         Directs function to convert Series index to np.datetime64[ns] or
         leave as np.int64.
+
+    agg : str, default: "mean"
+        Specify the StatPoint field (e.g. aggregating function) to create the Series
+        from. Must be one of "min", "mean", "max", "count", or "stddev". This
+        argument is ignored if RawPoint values are passed into the function.
 
     """
     try:
@@ -61,9 +66,12 @@ def to_series(stream_set, datetime64_index=True):
 
     for idx, output in enumerate(stream_set.values()):
         times, values = [], []
-        for item in output:
-            times.append(item.time)
-            values.append(item.value)
+        for point in output:
+            times.append(point.time)
+            if point.__class__.__name__ == "RawPoint":
+                values.append(point.value)
+            else:
+                values.append(getattr(point, agg))
 
         if datetime64_index:
             times = pd.Index(times, dtype='datetime64[ns]')
@@ -73,7 +81,8 @@ def to_series(stream_set, datetime64_index=True):
         ))
     return result
 
-def to_dataframe(stream_set, columns=None):
+
+def to_dataframe(stream_set, columns=None, agg="mean"):
     """
     Returns a Pandas DataFrame object indexed by time and using the values of a
     stream for each column.
@@ -82,6 +91,12 @@ def to_dataframe(stream_set, columns=None):
     ----------
     columns: sequence
         column names to use for DataFrame
+
+    agg : str, default: "mean"
+        Specify the StatPoint field (e.g. aggregating function) to create the Series
+        from. Must be one of "min", "mean", "max", "count", or "stddev". This
+        argument is ignored if RawPoint values are passed into the function.
+
     """
     try:
         import pandas as pd
@@ -90,10 +105,10 @@ def to_dataframe(stream_set, columns=None):
 
     stream_names = _stream_names(stream_set)
     columns = columns if columns else ["time"] + list(stream_names)
-    return pd.DataFrame(to_dict(stream_set), columns=columns).set_index("time")
+    return pd.DataFrame(to_dict(stream_set,agg=agg), columns=columns).set_index("time")
 
 
-def to_array(stream_set):
+def to_array(stream_set, agg="mean"):
     """
     Returns a list of Numpy arrays (one per stream) containing point classes.
     """
@@ -102,13 +117,30 @@ def to_array(stream_set):
     except ImportError:
         raise ImportError("Please install Numpy to use this transformation function.")
 
-    return [np.array(output) for output in stream_set.values()]
+    results = []
+    for points in stream_set.values():
+        segment = []
+        for point in points:
+            if point.__class__.__name__ == "RawPoint":
+                segment.append(point.value)
+            else:
+                segment.append(getattr(point, agg))
+        results.append(segment)
+    return np.array(results)
 
 
-def to_dict(stream_set):
+def to_dict(stream_set, agg="mean"):
     """
     Returns a list of OrderedDict for each time code with the appropriate
     stream data attached.
+
+    Parameters
+    ----------
+    agg : str, default: "mean"
+        Specify the StatPoint field (e.g. aggregating function) to constrain dict
+        keys. Must be one of "min", "mean", "max", "count", or "stddev". This
+        argument is ignored if RawPoint values are passed into the function.
+
     """
     data = []
     stream_names = _stream_names(stream_set)
@@ -120,12 +152,12 @@ def to_dict(stream_set):
             if row[idx].__class__.__name__ == "RawPoint":
                 item[col] = row[idx].value if row[idx] else None
             else:
-                item[col] = row[idx].mean if row[idx] else None
+                item[col] = getattr(row[idx], agg) if row[idx] else None
         data.append(item)
     return data
 
 
-def to_csv(stream_set, fobj, dialect=None, fieldnames=None):
+def to_csv(stream_set, fobj, dialect=None, fieldnames=None, agg="mean"):
     """
     Saves stream data as a CSV file.
 
@@ -142,6 +174,10 @@ def to_csv(stream_set, fobj, dialect=None, fieldnames=None):
         A sequence of strings to use as fieldnames in the CSV header.  See
         Python's csv module for more information.
 
+    agg : str, default: "mean"
+        Specify the StatPoint field (e.g. aggregating function) to return when
+        limiting results. Must be one of "min", "mean", "max", "count", or "stddev".
+        This argument is ignored if RawPoint values are passed into the function.
     """
 
     @contextlib.contextmanager
@@ -164,21 +200,29 @@ def to_csv(stream_set, fobj, dialect=None, fieldnames=None):
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames, dialect=dialect)
         writer.writeheader()
 
-        for item in to_dict(stream_set):
+        for item in to_dict(stream_set, agg=agg):
             writer.writerow(item)
 
 
-def to_table(stream_set):
+def to_table(stream_set, agg="mean"):
     """
     Returns string representation of the data in tabular form using the tabulate
     library.
+
+    Parameters
+    ----------
+    agg : str, default: "mean"
+        Specify the StatPoint field (e.g. aggregating function) to create the Series
+        from. Must be one of "min", "mean", "max", "count", or "stddev". This
+        argument is ignored if RawPoint values are passed into the function.
+
     """
     try:
         from tabulate import tabulate
     except ImportError:
         raise ImportError("Please install tabulate to use this transformation function.")
 
-    return tabulate(stream_set.to_dict(), headers="keys")
+    return tabulate(stream_set.to_dict(agg=agg), headers="keys")
 
 
 ##########################################################################

--- a/btrdb/transformers.py
+++ b/btrdb/transformers.py
@@ -117,7 +117,10 @@ def to_dict(stream_set):
             "time": _get_time_from_row(row),
         })
         for idx, col in enumerate(stream_names):
-            item[col] = row[idx].value if row[idx] else None
+            if row[idx].__class__.__name__ == "RawPoint":
+                item[col] = row[idx].value if row[idx] else None
+            else:
+                item[col] = row[idx].mean if row[idx] else None
         data.append(item)
     return data
 

--- a/tests/btrdb/test_transformers.py
+++ b/tests/btrdb/test_transformers.py
@@ -199,6 +199,24 @@ class TestTransformers(object):
             assert (result[idx] == expected[idx]).all()     # verify data
             assert result[idx].name == expected_names[idx]  # verify name
 
+    def test_to_series_statpoint(self, statpoint_streamset):
+        """
+        Asserts to_series produces correct results with statpoints
+        """
+        result = to_series(statpoint_streamset)
+        values = [2.0, 4.0, 6.0, 8.0]
+        index = [1500000000100000000, 1500000000300000000, 1500000000500000000, 1500000000700000000]
+        assert (result[0] == Series(values, index=index)).all()
+
+        values = [3.0, 5.0, 7.0, 9.0]
+        index = [1500000000100000000, 1500000000300000000, 1500000000500000000, 1500000000700000000]
+        assert (result[1] == Series(values, index=index)).all()
+
+        result = to_series(statpoint_streamset, agg="max")
+        values = [2.5, 4.5, 6.5, 8.5]
+        index = [1500000000100000000, 1500000000300000000, 1500000000500000000, 1500000000700000000]
+        assert (result[0] == Series(values, index=index)).all()
+
     def test_to_series_index_type(self, streamset):
         """
         assert default index type is 'datetime64[ns]'
@@ -293,4 +311,28 @@ class TestTransformers(object):
         assert result == expected["to_dict"]
 
     def test_to_table(self, streamset):
+        """
+        asserts to_table returns formatted ASCII table
+        """
         assert to_table(streamset) == expected["table"]
+
+
+    def test_to_table(self, statpoint_streamset):
+        """
+        asserts to_table handles statpoints with requested key
+        """
+        expected = """               time    test/stream0    test/stream1    test/stream2    test/stream3
+-------------------  --------------  --------------  --------------  --------------
+1500000000100000000               2               4               6               8
+1500000000300000000               3               5               7               9
+1500000000500000000               4               6               8              10
+1500000000700000000               5               7               9              11"""
+        assert to_table(statpoint_streamset) == expected
+
+        expected = """               time    test/stream0    test/stream1    test/stream2    test/stream3
+-------------------  --------------  --------------  --------------  --------------
+1500000000100000000             2.5             4.5             6.5             8.5
+1500000000300000000             3.5             5.5             7.5             9.5
+1500000000500000000             4.5             6.5             8.5            10.5
+1500000000700000000             5.5             7.5             9.5            11.5"""
+        assert to_table(statpoint_streamset, agg="max") == expected

--- a/tests/btrdb/test_transformers.py
+++ b/tests/btrdb/test_transformers.py
@@ -67,6 +67,33 @@ def streamset():
     return obj
 
 
+@pytest.fixture
+def statpoint_streamset():
+    rows = [
+        [StatPoint(1500000000100000000, 0, 2.0, 2.5, 10, 1),StatPoint(1500000000100000000, 0, 4.0, 4.5, 11, 1),StatPoint(1500000000100000000, 0, 6.0, 6.5, 10, 1),StatPoint(1500000000100000000, 0, 8.0, 8.5, 11, 2)],
+        [StatPoint(1500000000300000000, 0, 3.0, 3.5, 11, 1),StatPoint(1500000000300000000, 0, 5.0, 5.5, 10, 1),StatPoint(1500000000300000000, 0, 7.0, 7.5, 10, 1),StatPoint(1500000000300000000, 0, 9.0, 9.5, 11, 2)],
+        [StatPoint(1500000000500000000, 0, 4.0, 4.5, 10, 1),StatPoint(1500000000500000000, 0, 6.0, 6.5, 11, 1),StatPoint(1500000000500000000, 0, 8.0, 8.5, 10, 1),StatPoint(1500000000500000000, 0, 10.0, 10.5, 11, 2)],
+        [StatPoint(1500000000700000000, 0, 5.0, 5.5, 11, 1),StatPoint(1500000000700000000, 0, 7.0, 7.5, 10, 1),StatPoint(1500000000700000000, 0, 9.0, 9.5, 10, 1),StatPoint(1500000000700000000, 0, 11.0, 11.5, 11, 2)],
+    ]
+    values = [
+        [StatPoint(1500000000100000000, 0, 2.0, 2.5, 10, 1),StatPoint(1500000000300000000, 0, 4.0, 4.5, 11, 1),StatPoint(1500000000500000000, 0, 6.0, 6.5, 10, 1),StatPoint(1500000000700000000, 0, 8.0, 8.5, 11, 2)],
+        [StatPoint(1500000000100000000, 1, 3.0, 3.5, 11, 1),StatPoint(1500000000300000000, 1, 5.0, 5.5, 10, 1),StatPoint(1500000000500000000, 1, 7.0, 7.5, 10, 1),StatPoint(1500000000700000000, 1, 9.0, 9.5, 11, 2)],
+        [StatPoint(1500000000100000000, 2, 4.0, 4.5, 10, 1),StatPoint(1500000000300000000, 2, 6.0, 6.5, 11, 1),StatPoint(1500000000500000000, 2, 8.0, 8.5, 10, 1),StatPoint(1500000000700000000, 2, 10.0, 10.5, 11, 2)],
+        [StatPoint(1500000000100000000, 3, 5.0, 5.5, 11, 1),StatPoint(1500000000300000000, 3, 7.0, 7.5, 10, 1),StatPoint(1500000000500000000, 3, 9.0, 9.5, 10, 1),StatPoint(1500000000700000000, 3, 11.0, 11.5, 11, 2)],
+    ]
+    streams = []
+    for idx in range(4):
+        stream = Mock(Stream)
+        type(stream).collection = PropertyMock(return_value="test")
+        type(stream).name = PropertyMock(return_value="stream{}".format(idx))
+        streams.append(stream)
+
+    obj = StreamSet(streams)
+    obj.rows = Mock(return_value=rows)
+    obj.values = Mock(return_value=values)
+    return obj
+
+
 expected = {
     "to_dict": [
         {'time': 1500000000000000000, 'test/stream0': None, 'test/stream1': 1.0, 'test/stream2': 1.0, 'test/stream3': 1.0},
@@ -81,34 +108,10 @@ expected = {
         {'time': 1500000000900000000, 'test/stream0': 10.0, 'test/stream1': None, 'test/stream2': 10.0, 'test/stream3': 10.0}
     ],
     "to_array": [
-        np.array([RawPoint(1500000000100000000, 2.0),
-            RawPoint(1500000000300000000, 4.0),
-            RawPoint(1500000000500000000, 6.0),
-            RawPoint(1500000000700000000, 8.0),
-            RawPoint(1500000000900000000, 10.0)]),
-        np.array([RawPoint(1500000000000000000, 1.0),
-            RawPoint(1500000000200000000, 3.0),
-            RawPoint(1500000000400000000, 5.0),
-            RawPoint(1500000000600000000, 7.0),
-            RawPoint(1500000000800000000, 9.0)]),
-        np.array([RawPoint(1500000000000000000, 1.0),
-            RawPoint(1500000000100000000, 2.0),
-            RawPoint(1500000000300000000, 4.0),
-            RawPoint(1500000000400000000, 5.0),
-            RawPoint(1500000000600000000, 7.0),
-            RawPoint(1500000000700000000, 8.0),
-            RawPoint(1500000000800000000, 9.0),
-            RawPoint(1500000000900000000, 10.0)]),
-        np.array([RawPoint(1500000000000000000, 1.0),
-            RawPoint(1500000000100000000, 2.0),
-            RawPoint(1500000000200000000, 3.0),
-            RawPoint(1500000000300000000, 4.0),
-            RawPoint(1500000000400000000, 5.0),
-            RawPoint(1500000000500000000, 6.0),
-            RawPoint(1500000000600000000, 7.0),
-            RawPoint(1500000000700000000, 8.0),
-            RawPoint(1500000000800000000, 9.0),
-            RawPoint(1500000000900000000, 10.0)])
+        np.array([2.0, 4.0, 6.0, 8.0, 10.0]),
+        np.array([1.0, 3.0, 5.0, 7.0, 9.0]),
+        np.array([1.0, 2.0, 4.0, 5.0, 7.0, 8.0, 9.0, 10.0]),
+        np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]),
     ],
     "table": """               time    test/stream0    test/stream1    test/stream2    test/stream3
 -------------------  --------------  --------------  --------------  --------------
@@ -145,10 +148,40 @@ class TestTransformers(object):
     def test_to_dict(self, streamset):
         assert to_dict(streamset) == expected["to_dict"]
 
+    def test_to_dict_statpoint(self, statpoint_streamset):
+        expected = [
+            {'time': 1500000000100000000, 'test/stream0': 2.0, 'test/stream1': 4.0, 'test/stream2': 6.0, 'test/stream3': 8.0},
+            {'time': 1500000000300000000, 'test/stream0': 3.0, 'test/stream1': 5.0, 'test/stream2': 7.0, 'test/stream3': 9.0},
+            {'time': 1500000000500000000, 'test/stream0': 4.0, 'test/stream1': 6.0, 'test/stream2': 8.0, 'test/stream3': 10.0},
+            {'time': 1500000000700000000, 'test/stream0': 5.0, 'test/stream1': 7.0, 'test/stream2': 9.0, 'test/stream3': 11.0},
+        ]
+        assert to_dict(statpoint_streamset) == expected
+
     def test_to_array(self, streamset):
+        """
+        asserts to_array of rawpoint returns multidimensional ndarry of values
+        """
         result = to_array(streamset)
         for idx in range(4):
             assert (result[idx] == expected["to_array"][idx]).all()
+
+    def test_to_array_statpoint(self, statpoint_streamset):
+        """
+        asserts to_array of statpoint returns ndarry of requested values
+        """
+        result = to_array(statpoint_streamset)
+        assert result.__class__ == np.ndarray
+        assert (result[0] == np.array([2.0, 4.0, 6.0, 8.0])).all()
+        assert (result[1] == np.array([3.0, 5.0, 7.0, 9.0])).all()
+        assert (result[2] == np.array([4.0, 6.0, 8.0, 10.0])).all()
+        assert (result[3] == np.array([5.0, 7.0, 9.0, 11.0])).all()
+
+        result = to_array(statpoint_streamset, agg="min")
+        assert result.__class__ == np.ndarray
+        assert (result[0] == np.array([0.0, 0.0, 0.0, 0.0,])).all()
+        assert (result[1] == np.array([1.0, 1.0, 1.0, 1.0, ])).all()
+        assert (result[2] == np.array([2.0, 2.0, 2.0, 2.0, ])).all()
+        assert (result[3] == np.array([3.0, 3.0, 3.0, 3.0, ])).all()
 
     def test_to_series(self, streamset):
         """
@@ -182,6 +215,14 @@ class TestTransformers(object):
         for series in result:
             assert series.index.dtype.name == 'int64'
 
+    def test_to_series_index_as_int(self, streamset):
+        """
+        assert datetime64_index: False produces 'int64' index
+        """
+        result = to_series(streamset, False)
+        for series in result:
+            assert series.index.dtype.name == 'int64'
+
     def test_to_dataframe(self, streamset):
         """
         assert to_dateframe works on RawPoints
@@ -191,31 +232,35 @@ class TestTransformers(object):
         df.set_index("time", inplace=True)
         assert to_dataframe(streamset).equals(df)
 
-    def test_to_dataframe_statpoints(self):
+    def test_to_dataframe_statpoints(self, statpoint_streamset):
         """
         assert to_dateframe works on StatPoints
         """
-        rows = [
-            [StatPoint(1500000000100000000, 0, 2.0, 2.5, 10, 1),StatPoint(1500000000300000000, 0, 4.0, 4.5, 11, 1),StatPoint(1500000000500000000, 0, 6.0, 6.5, 10, 1),StatPoint(1500000000700000000, 0, 8.0, 8.5, 11, 2)],
-            [StatPoint(1500000000100000000, 0, 3.0, 3.5, 11, 1),StatPoint(1500000000300000000, 0, 5.0, 5.5, 10, 1),StatPoint(1500000000500000000, 0, 7.0, 7.5, 10, 1),StatPoint(1500000000700000000, 0, 9.0, 9.5, 11, 2)],
-            [StatPoint(1500000000100000000, 0, 4.0, 4.5, 10, 1),StatPoint(1500000000300000000, 0, 6.0, 6.5, 11, 1),StatPoint(1500000000500000000, 0, 8.0, 8.5, 10, 1),StatPoint(1500000000700000000, 0, 10.0, 10.5, 11, 2)],
-            [StatPoint(1500000000100000000, 0, 5.0, 5.5, 11, 1),StatPoint(1500000000300000000, 0, 7.0, 7.5, 10, 1),StatPoint(1500000000500000000, 0, 9.0, 9.5, 10, 1),StatPoint(1500000000700000000, 0, 11.0, 11.5, 11, 2)],
-        ]
-        streams = []
-        for idx in range(4):
-            stream = Mock(Stream)
-            type(stream).collection = PropertyMock(return_value="test")
-            type(stream).name = PropertyMock(return_value="stream{}".format(idx))
-            streams.append(stream)
-
-        obj = StreamSet(streams)
-        obj.rows = Mock(return_value=rows)
-        df = obj.to_dataframe()
+        df = statpoint_streamset.to_dataframe()
 
         assert df["test/stream0"].tolist() == [2.0, 3.0, 4.0, 5.0]
         assert df["test/stream1"].tolist() == [4.0, 5.0, 6.0, 7.0]
         assert df["test/stream2"].tolist() == [6.0, 7.0, 8.0, 9.0]
         assert df["test/stream3"].tolist() == [8.0, 9.0, 10.0, 11.0]
+
+    def test_to_dataframe_agg(self, statpoint_streamset):
+        """
+        assert to_dateframe respects agg argument for StatPoints
+        """
+        df = statpoint_streamset.to_dataframe(agg="count")
+        assert df["test/stream0"].tolist() == [10, 11, 10, 11]
+
+        df = statpoint_streamset.to_dataframe(agg="min")
+        assert df["test/stream3"].tolist() == [0, 0, 0, 0]
+
+        df = statpoint_streamset.to_dataframe(agg="mean")
+        assert df["test/stream0"].tolist() == [2, 3, 4, 5]
+
+        df = statpoint_streamset.to_dataframe(agg="max")
+        assert df["test/stream0"].tolist() == [2.5, 3.5, 4.5, 5.5]
+
+        df = statpoint_streamset.to_dataframe(agg="stddev")
+        assert df["test/stream0"].tolist() == [1, 1, 1, 1]
 
     def test_to_csv_as_path(self, streamset, tmpdir):
         path = os.path.join(tmpdir.dirname, "to_csv_test.csv")


### PR DESCRIPTION
The `to_dataframe` transformer is expecting RawPoints and will throw the following:

```
/usr/local/lib/python3.6/dist-packages/btrdb/transformers.py in to_dict(stream_set)
    118         })
    119         for idx, col in enumerate(stream_names):
--> 120             item[col] = row[idx].value if row[idx] else None
    121         data.append(item)
    122     return data

AttributeError: 'StatPoint' object has no attribute 'value'
```
Use the following code to reproduce:

```
import btrdb 
from btrdb.utils.timez import *
db = btrdb.connect(profile="ni4ai.org")
print(db.info())

streams = db.streams(
    "d0e18bd3-b304-4c10-be40-ff83df18fb38",
    "6f8ebaf0-78ea-416e-a0ff-5c3c5d83c270",
).filter(
    start=to_nanoseconds("2018-01-01T12:00:00Z"), 
    end=to_nanoseconds("2018-01-01T13:00:00Z")
)

streams = streams.windows(ns_delta(seconds=60), 10)
df = streams.to_dataframe()
```


ch1705