### PR TITLE
Adds support for Py 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: xenial
 python:
   - '3.6'
   - '3.7'
+  - '3.8'
 
 before_install:
   - sudo apt-get update

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,9 @@
-pytest==4.0.2
-pytest-cov==2.6.0
+pytest==5.3.2
+pytest-cov==2.8.1
 pytest-flakes==4.0.0
-freezegun==0.3.11
+freezegun==0.3.12
 
 # dependencies for conversions
 numpy>=1.15
 pandas
-tabulate==0.8.3
+tabulate==0.8.6


### PR DESCRIPTION
Python 3.8 was released in October 2019 with 3.8.1 released in December.  This PR adds Python 3.8 to the travis configuration and updates the testing dependency versions to maintain compatibility with 3.8.