### PR TITLE
handles case of missing btrdb in credentials yaml

### DIFF
--- a/btrdb/utils/credentials.py
+++ b/btrdb/utils/credentials.py
@@ -92,7 +92,7 @@ def credentials_by_profile(name=None):
         raise ProfileNotFound("Profile `{}` not found in credentials file.".format(name))
 
     # rename api_key if needed and return
-    fragment = creds[name]["btrdb"]
+    fragment = creds[name].get("btrdb", {})
     if "api_key" in fragment:
         fragment["apikey"] = fragment.pop("api_key")
     return fragment


### PR DESCRIPTION
To verify:

1. set pgops env to husky
2. rename `btrdb` to `btrdb2` in husky section of credentials  file
3. python -c "from btrdb import connect; print(connect().info())"