### PR TITLE
Update BTrDB Custom Serialization

### DIFF
--- a/btrdb/__init__.py
+++ b/btrdb/__init__.py
@@ -20,8 +20,8 @@ from btrdb.endpoint import Endpoint
 from btrdb.exceptions import ConnectionError
 from btrdb.version import get_version
 from btrdb.utils.credentials import credentials_by_profile, credentials
+from btrdb.utils.ray import register_serializer
 from btrdb.stream import MINIMUM_TIME, MAXIMUM_TIME
-from btrdb.utils import register_serializer
 from warnings import warn
 
 ##########################################################################

--- a/btrdb/__init__.py
+++ b/btrdb/__init__.py
@@ -21,7 +21,7 @@ from btrdb.exceptions import ConnectionError
 from btrdb.version import get_version
 from btrdb.utils.credentials import credentials_by_profile, credentials
 from btrdb.stream import MINIMUM_TIME, MAXIMUM_TIME
-from btrdb.util import register_serializer
+from btrdb.utils import register_serializer
 from warnings import warn
 
 ##########################################################################

--- a/btrdb/__init__.py
+++ b/btrdb/__init__.py
@@ -21,6 +21,8 @@ from btrdb.exceptions import ConnectionError
 from btrdb.version import get_version
 from btrdb.utils.credentials import credentials_by_profile, credentials
 from btrdb.stream import MINIMUM_TIME, MAXIMUM_TIME
+from btrdb.util import register_serializer
+from warnings import warn
 
 ##########################################################################
 ## Module Variables
@@ -40,7 +42,7 @@ BTRDB_PROFILE = "BTRDB_PROFILE"
 def _connect(endpoints=None, apikey=None):
     return BTrDB(Endpoint(Connection(endpoints, apikey=apikey).channel))
 
-def connect(conn_str=None, apikey=None, profile=None):
+def connect(conn_str=None, apikey=None, profile=None, shareable=False):
     """
     Connect to a BTrDB server.
 
@@ -57,6 +59,12 @@ def connect(conn_str=None, apikey=None, profile=None):
         The name of a profile containing the required connection information as
         found in the user's predictive grid credentials file
         `~/.predictivegrid/credentials.yaml`.
+    shareable: bool, default=False
+        Whether or not the connection can be "shared" in a distributed setting such
+        as Ray workers. If set to True, the connection can be serialized and sent
+        to other workers so that data can be retrieved in parallel; **however**, this
+        is less secure because it is possible for other users of the Ray cluster to
+        use your API key to fetch data.
 
     Returns
     -------
@@ -67,6 +75,11 @@ def connect(conn_str=None, apikey=None, profile=None):
     # do not allow user to provide both address and profile
     if conn_str and profile:
         raise ValueError("Received both conn_str and profile arguments.")
+
+    # check shareable flag and register custom serializer if necessary
+    if shareable:
+        warn("a shareable connection is potentially insecure; other users of the same cluster may be able to access your API key")
+        register_serializer(conn_str=conn_str, apikey=apikey, profile=profile)
 
     # use specific profile if requested
     if profile:

--- a/btrdb/utils/ray.py
+++ b/btrdb/utils/ray.py
@@ -22,7 +22,6 @@ def register_serializer(conn_str=None, apikey=None, profile=None):
         found in the user's predictive grid credentials file
         `~/.predictivegrid/credentials.yaml`.
     """
-    print("check init", ray.is_initialized())
     assert ray.is_initialized(), "Need to call ray.init() before registering custom serializer"
     ray.util.register_serializer(
     BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))

--- a/btrdb/utils/ray.py
+++ b/btrdb/utils/ray.py
@@ -2,6 +2,8 @@ from functools import partial
 
 import ray
 
+import semver
+
 import btrdb
 from btrdb.conn import BTrDB
 
@@ -24,13 +26,16 @@ def register_serializer(conn_str=None, apikey=None, profile=None):
     """
     assert ray.is_initialized(), "Need to call ray.init() before registering custom serializer"
     # TODO: check the version using the 'semver' package?
-    if ray.__version__ == "0.8.4":
+    ver = semver.VersionInfo.parse(ray.__version__)
+    if ver.major == 0:
         ray.register_custom_serializer(
         BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))
-    elif ray.__version__ in ["1.2.0", "1.3.0"]:
+    elif ver.major == 1 and ver.minor in range(2, 4):
     # TODO: check different versions of ray?
         ray.util.register_serializer(
         BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))
+    else:
+        raise Exception("Ray version %s does not have custom serialization. Please upgrade to >= 1.2.0" % ray.__version__)
 
 def btrdb_serializer(_):
     """

--- a/btrdb/utils/ray.py
+++ b/btrdb/utils/ray.py
@@ -23,8 +23,14 @@ def register_serializer(conn_str=None, apikey=None, profile=None):
         `~/.predictivegrid/credentials.yaml`.
     """
     assert ray.is_initialized(), "Need to call ray.init() before registering custom serializer"
-    ray.util.register_serializer(
-    BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))
+    # TODO: check the version using the 'semver' package?
+    if ray.__version__ == "0.8.4":
+        ray.register_custom_serializer(
+        BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))
+    elif ray.__version__ in ["1.2.0", "1.3.0"]:
+    # TODO: check different versions of ray?
+        ray.util.register_serializer(
+        BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))
 
 def btrdb_serializer(_):
     """

--- a/btrdb/utils/ray.py
+++ b/btrdb/utils/ray.py
@@ -22,6 +22,7 @@ def register_serializer(conn_str=None, apikey=None, profile=None):
         found in the user's predictive grid credentials file
         `~/.predictivegrid/credentials.yaml`.
     """
+    print("check init", ray.is_initialized())
     assert ray.is_initialized(), "Need to call ray.init() before registering custom serializer"
     ray.util.register_serializer(
     BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))

--- a/btrdb/utils/ray.py
+++ b/btrdb/utils/ray.py
@@ -22,7 +22,8 @@ def register_serializer(conn_str=None, apikey=None, profile=None):
         found in the user's predictive grid credentials file
         `~/.predictivegrid/credentials.yaml`.
     """
-    ray.register_custom_serializer(
+    assert ray.is_initialized(), "Need to call ray.init() before registering custom serializer"
+    ray.util.register_serializer(
     BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))
 
 def btrdb_serializer(_):


### PR DESCRIPTION
This adjusts the existing custom serialization method to work with the Ray 1.2.0 API

Usage looks like:

```python
import ray
import btrdb
from btrdb.utils.ray import register_serializer
conn  =  btrdb.connect(profile='whatever')
register_serializer(profile='whatever') # needs to be called *after* the initialization; will assert
ray.init(ignore_reinit_error=True)
```